### PR TITLE
JENKINS-71856 - Replace TeeOutputStream with Apache commons implementation

### DIFF
--- a/src/main/java/hudson/remoting/TeeOutputStream.java
+++ b/src/main/java/hudson/remoting/TeeOutputStream.java
@@ -24,7 +24,6 @@ import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 
-
 /**
  * @deprecated Use instead {@link org.apache.commons.io.output.TeeOutputStream}
  * 

--- a/src/main/java/hudson/remoting/TeeOutputStream.java
+++ b/src/main/java/hudson/remoting/TeeOutputStream.java
@@ -24,13 +24,17 @@ import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 
+
 /**
+ * @deprecated Use instead {@link org.apache.commons.io.output.TeeOutputStream}
+ * 
  * Classic splitter of OutputStream. Named after the unix 'tee'
  * command. It allows a stream to be branched off so there
  * are now two streams.
  *
  * @version $Id: TeeOutputStream.java 610010 2008-01-08 14:50:59Z niallp $
  */
+@Deprecated
 @Restricted(NoExternalUse.class)
 public class TeeOutputStream extends FilterOutputStream {
 

--- a/src/main/java/org/jenkinsci/remoting/engine/WorkDirManager.java
+++ b/src/main/java/org/jenkinsci/remoting/engine/WorkDirManager.java
@@ -28,7 +28,7 @@ package org.jenkinsci.remoting.engine;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import hudson.remoting.TeeOutputStream;
+import org.apache.commons.io.output.TeeOutputStream;
 import org.jenkinsci.remoting.util.PathUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;


### PR DESCRIPTION
Per JIRA issue, this internal implementation of `TeeOutputStream` seems to have an obvious issue of double writing to the second `OutputStream`.  It's apparently gone un-fixed because this implementation has only been used in one place. Other uses of `TeeInputStream` around the Jenkins codebase use an alternate (and correct) implementation of `TeeInputStream` from Apache commons.

This PR replaces the only internal usage of the internal `TeeOutputStream` with the Apache Commons implementation, and marks the internal class as deprecated with a link.
